### PR TITLE
Fix to handling of no peaks in inter-impulse window

### DIFF
--- a/Pypsy/signal/analysis.py
+++ b/Pypsy/signal/analysis.py
@@ -175,7 +175,7 @@ def bateman_gauss(time, onset=0, amplitude=0, tau1=3.75, tau2=0.5, sigma=0):
         # We'll prepend and append extensions of the first and last values of
         # the Bateman output to either side of it. The length of each of these
         # extensions is 4*sigma
-        winwidth2 = np.ceil(sr * sigma * 4)
+        winwidth2 = int(np.ceil(sr * sigma * 4))
 
         # Create a time vector for the Gaussian window that is 2 * winwidth2 + 1
         t = np.arange(1, (winwidth2 * 2 + 1) + 1)

--- a/Pypsy/signal/analysis.py
+++ b/Pypsy/signal/analysis.py
@@ -807,7 +807,10 @@ def interimpulse_fit(driver, kernel, minima, maxima, original_time, original_sig
             # inter-impulse data over the window, or the original signal at the
             # nearest possible time index.
             closest_index, closest_time = Pypsy.signal.utilities.closest_time_index(original_time, grid_time[i])
-            tonic_level[i] = np.min([np.median(driver[grid_indices]),  original_signal[closest_index]])
+            if len(grid_indices) > 0:
+                tonic_level[i] = np.min([np.median(driver[grid_indices]),  original_signal[closest_index]])
+            else:
+                tonic_level[i] = original_signal[closest_index]
 
     # tonic_driver is the tonic_level signal PCHIP interpolated across the
     # original timestamps

--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 Ledalab functionality implemented in python originally by https://github.com/brennon
 
-Small fixes by me
+Small fixes by https://github.com/agostontorok

--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+Ledalab functionality implemented in python originally by https://github.com/brennon
+
+Small fixes by me


### PR DESCRIPTION
- added case for no peaks in the inter-impulse window
- minor: winwidth casted as int to avoid error when creating the time window